### PR TITLE
Added prestop to envoy sidecar

### DIFF
--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -80,6 +80,10 @@ const (
 	annotationSidecarProxyMemoryLimit   = "consul.hashicorp.com/sidecar-proxy-memory-limit"
 	annotationSidecarProxyMemoryRequest = "consul.hashicorp.com/sidecar-proxy-memory-request"
 
+
+	// annotationSidecarProxyPreStopDelay is the number of seconds to delay Envoy Sidecar shutdown
+	annotationSidecarProxyPreStopDelay = "consul.hashicorp.com/sidecar-proxy-prestop-delay"
+
 	// annotations for consul sidecar resource limits.
 	annotationConsulSidecarCPULimit      = "consul.hashicorp.com/consul-sidecar-cpu-limit"
 	annotationConsulSidecarCPURequest    = "consul.hashicorp.com/consul-sidecar-cpu-request"

--- a/control-plane/connect-inject/envoy_sidecar.go
+++ b/control-plane/connect-inject/envoy_sidecar.go
@@ -48,6 +48,18 @@ func (w *MeshWebhook) envoySidecar(namespace corev1.Namespace, pod corev1.Pod, m
 		Command: cmd,
 	}
 
+	if _, ok := pod.Annotations[annotationSidecarProxyPreStopDelay]; ok {
+		preStopHook := &corev1.Lifecycle{
+			PreStop: &corev1.Handler {
+				Exec: &corev1.ExecAction {
+					Command: []string{
+   	 					  	"/bin/sh",
+   	 					  	"-c",
+							"sleep " + pod.Annotations[annotationSidecarProxyPreStopDelay],
+   	 	}}}}
+		container.Lifecycle = preStopHook
+	}
+
 	tproxyEnabled, err := transparentProxyEnabled(namespace, pod, w.EnableTransparentProxy)
 	if err != nil {
 		return corev1.Container{}, err


### PR DESCRIPTION
Changes proposed in this PR:
- Added prestop hook to envoy sidecar
- Configure the time in the annotation

How I've tested this PR:
- I used the docker image locally and it worked in a test environment
- I tested the docker image in a dev cluster with real services and the configuration solved 5XX issues 

How I expect reviewers to test this PR:
- Compile and create the docker image using the target `control-plane-dev-docker` 
- Use this image in `connect-inject` deployment  
- Add the annotation `consul.hashicorp.com/sidecar-proxy-prestop-delay: 30s` in the deploy that is using service mesh 
- Validate that the envoy container has the `preStop` hook properly configured

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

